### PR TITLE
handle zero values

### DIFF
--- a/src/Casts/TimezonedDatetime.php
+++ b/src/Casts/TimezonedDatetime.php
@@ -37,7 +37,7 @@ class TimezonedDatetime implements CastsAttributes
      */
     public function get($model, $key, $value, $attributes)
     {
-        if(! $value) {
+        if(!$value && $value !== 0) {
             return null;
         }
         
@@ -57,7 +57,7 @@ class TimezonedDatetime implements CastsAttributes
      */
     public function set($model, $key, $value, $attributes)
     {
-        if(! $value) {
+        if(!$value && $value !== 0) {
             return null;
         }
 

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -123,3 +123,19 @@ it('can mutate empty string as NULL', function() {
 
     expect($output)->toBeNull();
 });
+
+
+it('can mutate 0 values', function() {
+    // 4 hours difference between dubai and UTC
+    setupFacade(current: 'Asia/Dubai');
+    
+    $cast = new TimezonedDatetime('H');
+
+    $input = 0;
+    
+    $output = $cast->set(fakeModel(), 'id', $input, []);
+    expect($output)->toEqual(20);
+
+    $output = $cast->get(fakeModel(), 'id', $input, []);
+    expect($output->format('H'))->toEqual(4);
+});


### PR DESCRIPTION
In our app, we have a use case where users specify the hour they want to receive updates.

for example: a user in Dubai want to receive updates at 4 am or at midnight (0) am.

we tried to use this package to handle the timezone conversion using 

```
protected $casts = [
    'notify_at' => TimezonedDatetime::class.  ':H'
]
```

but right now 0 values are causing to return [null](https://github.com/whitecube/laravel-timezones/blob/main/src/Casts/TimezonedDatetime.php#L40) from the casts.

This PR is to fix this issue