### PR TITLE
Fixed models serialization

### DIFF
--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
 use Whitecube\LaravelTimezones\Casts\TimezonedDatetime;
 
 it('can access UTC database date with application timezone', function() {
@@ -138,4 +140,24 @@ it('can mutate 0 values', function() {
 
     $output = $cast->get(fakeModel(), 'id', $input, []);
     expect($output->format('H'))->toEqual(4);
+});
+
+test('a model with a timezone date cast can be json serialized', function () {
+    setupFacade();
+
+    Config::shouldReceive('get')
+        ->with('app.timezone')
+        ->andReturn('UTC');
+
+    $date = new Carbon('2022-12-15 09:00:00', 'UTC');
+    $model = fakeModelWithCast();
+
+    $model->test_at = $date;
+    $model->updated_at = $date;
+
+    expect($model->jsonSerialize())
+        ->toBe([
+            'test_at' => $date->toJSON(),
+            'updated_at' => $date->toJSON()
+        ]);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use Whitecube\LaravelTimezones\Timezone;
 use Whitecube\LaravelTimezones\Facades\Timezone as Facade;
 use Illuminate\Database\Eloquent\Model;
+use Whitecube\LaravelTimezones\Casts\TimezonedDatetime;
 
 /*
 |--------------------------------------------------------------------------
@@ -54,6 +55,22 @@ function setupFacade(string $storage = 'UTC', string $current = 'Europe/Brussels
 function fakeModel()
 {
     return new class() extends Model {
+        public function getDateFormat()
+        {
+            return 'Y-m-d H:i:s';
+        }
+    };
+}
+
+function fakeModelWithCast()
+{
+    return new class() extends Model {
+        protected $casts = [
+            'test_at' => TimezonedDatetime::class,
+            'created_at' => TimezonedDatetime::class,
+            'updated_at' => TimezonedDatetime::class,
+        ];
+
         public function getDateFormat()
         {
             return 'Y-m-d H:i:s';


### PR DESCRIPTION
Previously, models that had a `TimezonedDatetime` cast on one of the timestamp columns (created_at, updated_at) would generate an exception when calling `jsonSerialize` on them.

This was because Laravel casts these timestamps to a JSON-compatible ISO string BEFORE running the custom cast, which means that by the time the cast ran, the value had already been converted and its format was not what the `TimezonedDatetime` cast expects.