### PR TITLE
Fixed cast set on timestamp attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $model->published_at = Timezone::date($request->published_at);
 
 ### Edge cases
 
-If you need to use the `TimezonedDatetime` cast on the timestamp columns (`created_at` and/or `updated_at`) AND you're expecting to handle dates with timezones other than UTC or the one you've defined with `Timezone::set()`, you will need to apply the `Whitecube\LaravelTimezones\Concerns\HasTimezonedTimestamps` trait on your model.
+If you need to use the `TimezonedDatetime` or `ImmutableTimezonedDatetime` casts on the default timestamp columns (`created_at` and/or `updated_at`) AND you're expecting to handle dates with timezones other than UTC or the one you've defined with `Timezone::set()`, you will need to apply the `Whitecube\LaravelTimezones\Concerns\HasTimezonedTimestamps` trait on your model.
 
 This is necessary to prevent Laravel's casting of those attributes to occur, which would transform the value in a way where the timezone information is lost, preventing our cast from working properly.
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ $model->published_at = Timezone::date($request->published_at);
 
 **This is not a bug**, it is intended behavior since one should be fully aware of the Carbon instance's timezone before assigning it.
 
+### Edge cases
+
+If you need to use the `TimezonedDatetime` cast on the timestamp columns (`created_at` and/or `updated_at`) AND you're expecting to handle dates with timezones other than UTC or the one you've defined with `Timezone::set()`, you will need to apply the `Whitecube\LaravelTimezones\Concerns\HasTimezonedTimestamps` trait on your model.
+
+This is necessary to prevent Laravel's casting of those attributes to occur, which would transform the value in a way where the timezone information is lost, preventing our cast from working properly.
+
+An example of a case where you need to use the trait:
+
+```php
+Timezone::set('Europe/Brussels');
+
+$model->created_at = new Carbon('2022-12-15 09:00:00', 'Asia/Taipei');
+```
+
+
 ## 🔥 Sponsorships 
 
 If you are reliant on this package in your production applications, consider [sponsoring us](https://github.com/sponsors/whitecube)! It is the best way to help us keep doing what we love to do: making great open source software.

--- a/src/Casts/TimezonedDatetime.php
+++ b/src/Casts/TimezonedDatetime.php
@@ -5,7 +5,6 @@ namespace Whitecube\LaravelTimezones\Casts;
 use Whitecube\LaravelTimezones\Facades\Timezone;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Carbon\Carbon;
-use Carbon\CarbonInterface;
 use DateTime;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Database\Eloquent\Model;
@@ -81,6 +80,7 @@ class TimezonedDatetime implements CastsAttributes
 
     /**
      * Check if the given key is part of the model's known timestamps
+     * 
      * @param Model $model 
      * @param string $key 
      * @return bool 
@@ -109,7 +109,13 @@ class TimezonedDatetime implements CastsAttributes
         return $date->shiftTimezone($timezone);
     }
 
-    protected function hasTimezone($value): bool
+    /**
+     * Check if the provided value contains timezone information
+     * 
+     * @param mixed $value 
+     * @return bool 
+     */
+    protected function hasTimezone(mixed $value): bool
     {
         return (is_string($value) && array_key_exists('zone', date_parse($value)))
             || (is_a($value, DateTime::class) && $value->getTimezone());

--- a/src/Concerns/HasTimezonedTimestamps.php
+++ b/src/Concerns/HasTimezonedTimestamps.php
@@ -21,8 +21,11 @@ trait HasTimezonedTimestamps
 
     /**
      * Check if key is a timezoned datetime cast
+     * 
+     * @param string $key 
+     * @return bool 
      */
-    protected function hasTimezonedDatetimeCast($key)
+    protected function hasTimezonedDatetimeCast(string $key): bool
     {
         $casts = $this->getCasts();
 

--- a/src/Concerns/HasTimezonedTimestamps.php
+++ b/src/Concerns/HasTimezonedTimestamps.php
@@ -28,8 +28,17 @@ trait HasTimezonedTimestamps
      */
     protected function hasTimezonedDatetimeCast(string $key): bool
     {
-        $casts = $this->getCasts();
+        $cast = $this->getCasts()[$key] ?? null;
 
-        return array_key_exists($key, $casts) && $casts[$key] === TimezonedDatetime::class;
+        if (! $cast) {
+            return false;
+        }
+
+        $castClassName = explode(':', $cast)[0];
+
+        return in_array(
+            $castClassName, 
+            [TimezonedDatetime::class, ImmutableTimezonedDatetime::class]
+        );
     }
 }

--- a/src/Concerns/HasTimezonedTimestamps.php
+++ b/src/Concerns/HasTimezonedTimestamps.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Whitecube\LaravelTimezones\Concerns;
+
+use Whitecube\LaravelTimezones\Casts\TimezonedDatetime;
+
+trait HasTimezonedTimestamps
+{
+    /**
+     * Determine if the given attribute is a date or date castable.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function isDateAttribute($key)
+    {
+        return (in_array($key, $this->getDates(), true) ||
+            $this->isDateCastable($key)) &&
+            ! $this->hasTimezonedDatetimeCast($key);
+    }
+
+    /**
+     * Check if key is a timezoned datetime cast
+     */
+    protected function hasTimezonedDatetimeCast($key)
+    {
+        $casts = $this->getCasts();
+
+        return array_key_exists($key, $casts) && $casts[$key] === TimezonedDatetime::class;
+    }
+}

--- a/src/Concerns/HasTimezonedTimestamps.php
+++ b/src/Concerns/HasTimezonedTimestamps.php
@@ -3,6 +3,7 @@
 namespace Whitecube\LaravelTimezones\Concerns;
 
 use Whitecube\LaravelTimezones\Casts\TimezonedDatetime;
+use Whitecube\LaravelTimezones\Casts\ImmutableTimezonedDatetime;
 
 trait HasTimezonedTimestamps
 {

--- a/src/DatetimeParser.php
+++ b/src/DatetimeParser.php
@@ -9,8 +9,18 @@ class DatetimeParser
 {
     use HasAttributes;
 
+    /**
+     * The model's date storage format
+     */
     protected ?string $format;
 
+    /**
+     * Parse the value into a carbon instance
+     * 
+     * @param mixed $value 
+     * @param null|string $format 
+     * @return Carbon 
+     */
     public function parse(mixed $value, ?string $format): Carbon
     {
         $this->format = $format;

--- a/src/DatetimeParser.php
+++ b/src/DatetimeParser.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Whitecube\LaravelTimezones;
+
+use Illuminate\Database\Eloquent\Concerns\HasAttributes;
+use Illuminate\Support\Carbon;
+
+class DatetimeParser
+{
+    use HasAttributes;
+
+    protected ?string $format;
+
+    public function parse(mixed $value, ?string $format): Carbon
+    {
+        $this->format = $format;
+
+        return $this->asDateTime($value);
+    }
+
+
+    /**
+     * Get the format for database stored dates.
+     *
+     * @return string
+     */
+    public function getDateFormat()
+    {
+        return $this->format;
+    }
+}

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -161,3 +161,63 @@ test('a model with a timezone date cast can be json serialized', function () {
             'updated_at' => $date->toJSON()
         ]);
 });
+
+test('a model with a timezone date cast can parse ISO-formatted values properly', function () {
+    setupFacade();
+
+    Config::shouldReceive('get')
+        ->with('app.timezone')
+        ->andReturn('UTC');
+
+    $date = new Carbon('2022-12-15 09:00:00', 'UTC');
+    $model = fakeModelWithCast();
+
+    $model->test_at = $date->toIso8601String();
+    $model->updated_at = $date->toIso8601String();
+
+    expect($model->jsonSerialize())
+        ->toBe([
+            'test_at' => $date->toJSON(),
+            'updated_at' => $date->toJSON()
+        ]);
+});
+
+test('a model with a timezone date cast can parse datetime values properly', function () {
+    setupFacade();
+
+    Config::shouldReceive('get')
+        ->with('app.timezone')
+        ->andReturn('UTC');
+
+    $date = new DateTime('2022-12-15 09:00:00');
+    $model = fakeModelWithCast();
+
+    $model->test_at = $date;
+    $model->updated_at = $date;
+
+    expect($model->jsonSerialize())
+        ->toBe([
+            'test_at' => '2022-12-15T09:00:00.000000Z',
+            'updated_at' => '2022-12-15T09:00:00.000000Z'
+        ]);
+});
+
+test('a model with a timezone date cast can parse datetime values with a defined timezone properly', function () {
+    setupFacade();
+
+    Config::shouldReceive('get')
+        ->with('app.timezone')
+        ->andReturn('UTC');
+
+    $date = new DateTime('2022-12-15 09:00:00', new DateTimeZone('Asia/Taipei'));
+    $model = fakeModelWithCast();
+
+    $model->test_at = $date;
+    $model->updated_at = $date;
+
+    expect($model->jsonSerialize())
+        ->toBe([
+            'test_at' => '2022-12-15T01:00:00.000000Z',
+            'updated_at' => '2022-12-15T01:00:00.000000Z'
+        ]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,6 +4,7 @@ use Whitecube\LaravelTimezones\Timezone;
 use Whitecube\LaravelTimezones\Facades\Timezone as Facade;
 use Illuminate\Database\Eloquent\Model;
 use Whitecube\LaravelTimezones\Casts\TimezonedDatetime;
+use Whitecube\LaravelTimezones\Concerns\HasTimezonedTimestamps;
 
 /*
 |--------------------------------------------------------------------------
@@ -65,6 +66,8 @@ function fakeModel()
 function fakeModelWithCast()
 {
     return new class() extends Model {
+        use HasTimezonedTimestamps;
+        
         protected $casts = [
             'test_at' => TimezonedDatetime::class,
             'created_at' => TimezonedDatetime::class,


### PR DESCRIPTION
This fixes a bug where the set method on the cast would break if we provided it with a string that did not match the model's date format. Now, the cast uses Laravel's own datetime parsing, which handles all the expected use cases for this package to be a drop-in replacement for a 'datetime' cast.

This also fixes a bug where the TimezonedDatetime cast was not working properly when used with default Laravel timestamps (created_at, updated_at). It would lose the provided timezone value, because the value was first cast to a string (`Y-m-d H:i:s`) by Laravel's internal date casting.

The solution is unfortunately to add the `Whitecube\LaravelTimezones\HasTimezonedTimestamps` trait to your models if you need to use the `TimezonedDatetime` cast on the `created_at` and/or `updated_at` columns.

> **Note**: This is only necessary if you're allowing date values with different timezone data than you're excpecting (so anything other than UTC or the timezone you've defined with `Timezone::set(...)`).

