### PR TITLE
PHP 7.3 support and default parameter resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
-        "laravel/framework": "^9|^10|^11",
+        "php": ">=7.3",
+        "laravel/framework": "^8|^9|^10|^11",
         "nesbot/carbon": "^2.64|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",
-        "pestphp/pest": "^2.34"
+        "pestphp/pest": "^1.23"
     },
     "extra": {
         "laravel": {

--- a/src/Casts/ImmutableTimezonedDatetime.php
+++ b/src/Casts/ImmutableTimezonedDatetime.php
@@ -2,14 +2,22 @@
 
 namespace Whitecube\LaravelTimezones\Casts;
 
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;
 
 class ImmutableTimezonedDatetime extends TimezonedDatetime
 {
     /**
      * Cast the given value.
+     *
+     * @param  Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return CarbonImmutable|CarbonInterface|null
      */
-    public function get(Model $model, string $key, mixed $value, array $attributes)
+    public function get($model, string $key, $value, array $attributes)
     {
         if($date = parent::get($model, $key, $value, $attributes)) {
             return $date->toImmutable();

--- a/src/DatetimeParser.php
+++ b/src/DatetimeParser.php
@@ -11,13 +11,19 @@ class DatetimeParser
 
     /**
      * The model's date storage format.
+     *
+     * @var null|string
      */
-    protected ?string $format;
+    protected $format;
 
     /**
      * Parse the value into a carbon instance.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $format
+     * @return CarbonInterface
      */
-    public function parse(mixed $value, ?string $format): CarbonInterface
+    public function parse($value, ?string $format): CarbonInterface
     {
         $this->format = $format;
 

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -13,15 +13,22 @@ class Timezone
 
     /**
      * The app's current display & manipulation timezone.
+     *
+     * @var CarbonTimeZone
      */
-    protected CarbonTimeZone $current;
+    protected $current;
+
     /**
      * The app's current storage timezone.
+     *
+     * @var CarbonTimeZone
      */
-    protected CarbonTimeZone $storage;
+    protected $storage;
 
     /**
      * Create a new singleton instance.
+     *
+     * @throws \Exception
      */
     public function __construct(string $default)
     {
@@ -30,19 +37,24 @@ class Timezone
     }
 
     /**
-     * @alias setCurrent
-     *
      * Set the current application timezone.
+     *
+     * @param  mixed|null  $timezone
+     * @alias setCurrent
+     * @throws \Exception
      */
-    public function set(mixed $timezone = null): void
+    public function set($timezone = null): void
     {
         $this->setCurrent($timezone);
     }
 
     /**
      * Set the current application timezone.
+     *
+     * @param  mixed  $timezone
+     * @throws \Exception
      */
-    public function setCurrent(mixed $timezone): void
+    public function setCurrent($timezone): void
     {
         $this->current = $this->makeTimezone($timezone);
     }
@@ -57,8 +69,11 @@ class Timezone
 
     /**
      * Set the current database timezone.
+     *
+     * @param  mixed  $timezone
+     * @throws \Exception
      */
-    public function setStorage(mixed $timezone): void
+    public function setStorage($timezone): void
     {
         $this->storage = $this->makeTimezone($timezone);
     }
@@ -81,16 +96,24 @@ class Timezone
 
     /**
      * Configure given date for the application's current timezone.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $maker
+     * @return CarbonInterface
      */
-    public function date(mixed $value, callable $maker = null): CarbonInterface
+    public function date($value, callable $maker = null): CarbonInterface
     {
         return $this->makeDateWithCurrent($value, $maker);
     }
 
     /**
      * Configure given date for the database storage timezone.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $maker
+     * @return CarbonInterface
      */
-    public function store(mixed $value, callable $maker = null): CarbonInterface
+    public function store($value, callable $maker = null): CarbonInterface
     {
         return $this->makeDateWithStorage($value, $maker);
     }
@@ -113,8 +136,12 @@ class Timezone
 
     /**
      * Create or configure date using the application's current timezone.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $maker
+     * @return CarbonInterface
      */
-    protected function makeDateWithCurrent(mixed $value, callable $maker = null): CarbonInterface
+    protected function makeDateWithCurrent($value, callable $maker = null): CarbonInterface
     {
         return is_a($value, CarbonInterface::class)
             ? $this->convertToCurrent($value)
@@ -123,8 +150,12 @@ class Timezone
 
     /**
      * Create or configure date using the database's storage timezone.
+     *
+     * @param  mixed  $value
+     * @param  callable|null  $maker
+     * @return CarbonInterface
      */
-    protected function makeDateWithStorage(mixed $value, callable $maker = null): CarbonInterface
+    protected function makeDateWithStorage($value, callable $maker = null): CarbonInterface
     {
         return is_a($value, CarbonInterface::class)
             ? $this->convertToStorage($value)
@@ -133,8 +164,13 @@ class Timezone
 
     /**
      * Create a date using the provided timezone.
+     *
+     * @param  mixed  $value
+     * @param  CarbonTimeZone  $timezone
+     * @param  callable|null  $maker
+     * @return CarbonInterface
      */
-    protected function makeDate(mixed $value, CarbonTimeZone $timezone, callable $maker = null): CarbonInterface
+    protected function makeDate($value, CarbonTimeZone $timezone, callable $maker = null): CarbonInterface
     {
         return ($maker)
             ? call_user_func($maker, $value, $timezone)
@@ -143,8 +179,12 @@ class Timezone
 
     /**
      * Create a Carbon timezone from given value.
+     *
+     * @param  mixed  $value
+     * @return CarbonTimeZone
+     * @throws \Exception
      */
-    protected function makeTimezone(mixed $value): CarbonTimeZone
+    protected function makeTimezone($value): CarbonTimeZone
     {
         if(! is_a($value, CarbonTimeZone::class)) {
             $value = new CarbonTimeZone($value);

--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -30,8 +30,12 @@ class Timezone
      *
      * @throws \Exception
      */
-    public function __construct(string $default)
+    public function __construct(string $default = '')
     {
+        if (empty($default)) {
+            $default = config('app.timezone');
+        }
+
         $this->setStorage($default);
         $this->setCurrent($default);
     }


### PR DESCRIPTION
* Introduces backward-compatible support for PHP 7.3 with the same functionality.
* In some circumstances when Laravel is initialized standalone, the lack of a default value for the 'default' parameter prevents the dependency solver from starting the package throwing error "Unresolvable dependency resolving [Parameter #0 [  string $default ]] in class Whitecube\LaravelTimezones\Timezone"
