### PR TITLE
Fix Unresolvable dependency resolving [Parameter #0 [  string $default ]] in class Whitecube\LaravelTimezones\Timezone

### DIFF
--- a/src/Timezone.php
+++ b/src/Timezone.php
@@ -23,8 +23,12 @@ class Timezone
     /**
      * Create a new singleton instance.
      */
-    public function __construct(string $default)
+    public function __construct(string $default = '')
     {
+        if (empty($default)) {
+            $default = config('app.timezone');
+        }
+
         $this->setStorage($default);
         $this->setCurrent($default);
     }


### PR DESCRIPTION
In some circumstances when Laravel is initialized standalone, the lack of a default value for the 'default' parameter prevents the dependency solver from starting the package throwing error "Unresolvable dependency resolving [Parameter #0 [ string $default ]] in class Whitecube\LaravelTimezones\Timezone"