### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "laravel/framework": "^9|^10|^11|^12.0",
+        "laravel/framework": "^9|^10|^11|^12.0|^13.0",
         "nesbot/carbon": "^2.64|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary

Laravel 13 has been released and this package needs to update its framework version constraint to allow installation on Laravel 13 projects.

The package code is fully compatible with Laravel 13 — only the `composer.json` version constraint needs updating, from:

```
"laravel/framework": "^9|^10|^11|^12.0"
```

to:

```
"laravel/framework": "^9|^10|^11|^12.0|^13.0"
```

No other code changes are required.